### PR TITLE
setup.py: fix missing comma in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ tests_require = [
 
 
 install_requires = [
-    'opbeat>=3.1.4'
+    'opbeat>=3.1.4',
     'urllib3',
 ]
 


### PR DESCRIPTION
`pip install` said:

> Collecting opbeat>=3.1.4urllib3 (from opbeat-python-urllib3)
