### PR TITLE
It seems certifi is a sane default dependency to be installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ tests_require = [
 
 
 install_requires = [
+    'certifi',
     'opbeat>=3.1.4',
     'urllib3',
 ]


### PR DESCRIPTION
Without, the django command `python manage.py opbeat test` crashes the python interpreter due to infinite recursion.

```
INFO:urllib3.connectionpool:Starting new HTTPS connection (48): intake.opbeat.com
/home/nicolas/.virtualenvs/velodrome/lib/python3.5/site-packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)

WARNING:py.warnings:/home/nicolas/.virtualenvs/velodrome/lib/python3.5/site-packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)

Fatal Python error: Cannot recover from stack overflow.

Current thread 0x00007fd60b592740 (most recent call first):
  File "/usr/lib/python3.5/logging/__init__.py", line 1384 in makeRecord
  File "/usr/lib/python3.5/logging/__init__.py", line 1414 in _log
  File "/usr/lib/python3.5/logging/__init__.py", line 1279 in info
...
```
